### PR TITLE
Configurable entry node service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ resources:
 
 serviceAccount : ""
 
+entryNode:
+  service:
+    name: "mongoose-entry-node-svc"
+
 debug: false
 
 ################## Mongoose CLI args ##################

--- a/mongoose-service/templates/mongoose-entry-node-svc.yaml
+++ b/mongoose-service/templates/mongoose-entry-node-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.entryNode.serviceName }}
+  name: {{ .Values.entryNode.service.name }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.serviceAccount }}

--- a/mongoose-service/templates/mongoose-entry-node-svc.yaml
+++ b/mongoose-service/templates/mongoose-entry-node-svc.yaml
@@ -10,9 +10,9 @@ spec:
   ports:
     - name: data
       port: 1099
-      targetPort: {{ .Values.dataPort }}
+      targetPort: {{ .Values.service.dataPort }}
     - name: http
       port: 9999
-      targetPort: {{ .Values.httpPort }}
+      targetPort: {{ .Values.service.httpPort }}
   selector:
     statefulset.kubernetes.io/pod-name: {{ .Values.pod.name }}-0

--- a/mongoose-service/templates/mongoose-entry-node-svc.yaml
+++ b/mongoose-service/templates/mongoose-entry-node-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongoose-entry-node-svc
+  name: {{ .Values.entryNode.serviceName }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.serviceAccount }}

--- a/mongoose-service/templates/mongoose-entry-node-svc.yaml
+++ b/mongoose-service/templates/mongoose-entry-node-svc.yaml
@@ -10,9 +10,9 @@ spec:
   ports:
     - name: data
       port: 1099
-      targetPort: 1099
+      targetPort: {{ .Values.dataPort }}
     - name: http
       port: 9999
-      targetPort: 9999
+      targetPort: {{ .Values.httpPort }}
   selector:
     statefulset.kubernetes.io/pod-name: {{ .Values.pod.name }}-0

--- a/mongoose-service/templates/service.yaml
+++ b/mongoose-service/templates/service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
     - name: data
       port: 1099
-      targetPort: 1099
+      targetPort: {{ .Values.dataPort }}
     - name: http
       port: 9999
-      targetPort: 9999
+      targetPort: {{ .Values.httpPort }}
 
     {{- if .Values.debug }}
     - name: debug

--- a/mongoose-service/templates/service.yaml
+++ b/mongoose-service/templates/service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
     - name: data
       port: 1099
-      targetPort: {{ .Values.dataPort }}
+      targetPort: {{ .Values.service.dataPort }}
     - name: http
       port: 9999
-      targetPort: {{ .Values.httpPort }}
+      targetPort: {{ .Values.service.httpPort }}
 
     {{- if .Values.debug }}
     - name: debug

--- a/mongoose-service/values.yaml
+++ b/mongoose-service/values.yaml
@@ -35,6 +35,8 @@ serviceAccount: ""
 entryNode:
   service:
     name: "mongoose-entry-node-svc"
+    httpPort: 9999
+    dataPort: 1099
 
 debug: false
 

--- a/mongoose-service/values.yaml
+++ b/mongoose-service/values.yaml
@@ -33,8 +33,8 @@ resources:
 serviceAccount: ""
 
 entryNode:
-    service:
-        name: "mongoose-entry-node-svc"
+  service:
+    name: "mongoose-entry-node-svc"
 
 debug: false
 

--- a/mongoose-service/values.yaml
+++ b/mongoose-service/values.yaml
@@ -35,8 +35,9 @@ serviceAccount: ""
 entryNode:
   service:
     name: "mongoose-entry-node-svc"
-    httpPort: 9999
-    dataPort: 1099
+
+httpPort: 9999
+dataPort: 1099
 
 debug: false
 

--- a/mongoose-service/values.yaml
+++ b/mongoose-service/values.yaml
@@ -21,6 +21,8 @@ pod:
 service:
   name: mongoose-svc
   type: LoadBalancer
+  httpPort: 9999
+  dataPort: 1099
 
 resources:
   limits:
@@ -35,9 +37,6 @@ serviceAccount: ""
 entryNode:
   service:
     name: "mongoose-entry-node-svc"
-
-httpPort: 9999
-dataPort: 1099
 
 debug: false
 

--- a/mongoose-service/values.yaml
+++ b/mongoose-service/values.yaml
@@ -32,6 +32,10 @@ resources:
 
 serviceAccount: ""
 
+entryNode:
+    service:
+        name: "mongoose-entry-node-svc"
+
 debug: false
 
 ################## Mongoose CLI args ##################

--- a/mongoose/templates/mongoose-entry-node-svc.yaml
+++ b/mongoose/templates/mongoose-entry-node-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongoose-entry-node-svc
+  name: {{ .Values.entryNode.service.name }}
   labels:
     app: {{ .Chart.Name }}
 spec:

--- a/mongoose/values.yaml
+++ b/mongoose/values.yaml
@@ -32,6 +32,10 @@ resources:
 
 serviceAccount : ""
 
+entryNode:
+  service:
+    name: "mongoose-entry-node-svc"
+
 debug: false
 
 ################## Mongoose CLI args ##################


### PR DESCRIPTION
**Use Case**
In case we need to deploy 2 Mongoose's packages (either standalone or distributed), we can't use helm - it won't be able to create entry node service with the same name and/or ports.
Installing a package via helm is great and it'd be good if we'd be able to deploy multiple packages of Mongoose using it.